### PR TITLE
Add support for SunOS (tested on SmartOS)

### DIFF
--- a/bbfreeze/freezer.py
+++ b/bbfreeze/freezer.py
@@ -550,10 +550,13 @@ if __name__ == '__main__':
             print "WARNING: failed to set RPATH for %s: %s" % (exe, out)
 
     def ensureRPath(self, exe):
-        if sys.platform not in ("linux2", "linux3"):
+        if sys.platform not in ("linux2", "linux3", "sunos5"):
             return
 
         expected_rpath = "${ORIGIN}:${ORIGIN}/../lib"
+        if sys.platform == "sunos5":
+            # RPATH shouldn't have the squiggly braces on sunos
+            expected_rpath = "$ORIGIN:$ORIGIN/../lib"
         current_rpath = self._getRPath(exe)
         if current_rpath is None:
             return

--- a/bbfreeze/getdeps.py
+++ b/bbfreeze/getdeps.py
@@ -138,6 +138,17 @@ elif sys.platform.startswith("freebsd"):
     def exclude(fp):
         return bool(re.match(r"^/usr/lib/.*$", fp))
 
+elif sys.platform.startswith("sunos5"):
+
+    def _getDependencies(path):
+        os.environ["P"] = path
+        s = commands.getoutput("ldd $P")
+        res = [x for x in re.compile(r"^\t* *.*=>\t* (.*)", re.MULTILINE).findall(s) if x]
+        return res
+
+    def exclude(fp):
+        return bool(re.match(r"^/lib/.*$|^/usr/lib/.*$", fp))
+
 elif sys.platform.startswith("linux"):
 
     def _getDependencies(path):


### PR DESCRIPTION
After patching bbfreeze like this I was able to do an esky build of saltstack on SmartOS.
