### PR TITLE
Excluding Crypt32.dll

### DIFF
--- a/bbfreeze/getdeps.py
+++ b/bbfreeze/getdeps.py
@@ -35,6 +35,7 @@ if sys.platform == 'win32':
          'COMCTL32.DLL',
          'COMDLG32.DLL',
          'CRTDLL.DLL',
+         'CRYPT32.DLL',
          'DCIMAN32.DLL',
          'DDRAW.DLL',
          'GDI32.DLL',


### PR DESCRIPTION
This is a windows system dll that is incompatible across OSs (XP to Vista+).
Freezing an app in Windows 7 with this dll included will make it unable to run on XP.
This change causes the frozen app to look for the OS provided version rather than bundling it.
