### PR TITLE
Adding a 'pe.close()' to getImports function to close/release mmap fi…

### DIFF
--- a/bbfreeze/getdeps.py
+++ b/bbfreeze/getdeps.py
@@ -81,6 +81,8 @@ if sys.platform == 'win32':
         except Exception, err:
             print "WARNING: could not determine binary dependencies for %r:%s" % (path, err)
             dlls = []
+        finally:
+            pe.close()
         return dlls
 
     _bpath = None


### PR DESCRIPTION
…le descriptors.

You can't call Freeze instances twice in a row on windows because the mmap is opened on `console.exe` (And prevents it from being deleted or moved after the first freeze). 
